### PR TITLE
Fix build script and organiser routes

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@ const portfinder    = require('portfinder');
 const cookieParser  = require('cookie-parser');
 
 const db              = require('./db');
+// expose the db instance so routers expecting `global.db` continue to work
+global.db = db;
 const authRouter      = require('./routes/auth');
 const { ensureAdmin } = require('./middleware/auth');
 const organiserRouter = require('./routes/organiser');

--- a/routes/organiser.js
+++ b/routes/organiser.js
@@ -259,7 +259,7 @@ router.post('/events/:id/edit', [
  * POST /organiser/events/:id/publish - Publish event
  * Changes event state from draft to published and sets publication timestamp
  */
-router.post('/organiser/events/:id/publish', (req, res, next) => {
+router.post('/events/:id/publish', (req, res, next) => {
   db.run(
     `UPDATE events 
      SET state = 'published', published_at = datetime('now')
@@ -276,7 +276,7 @@ router.post('/organiser/events/:id/publish', (req, res, next) => {
  * DELETE /organiser/events/:id - Delete event
  * Removes event and all associated tickets and bookings
  */
-router.delete('/organiser/events/:id', (req, res, next) => {
+router.delete('/events/:id', (req, res, next) => {
   db.run(
     'DELETE FROM events WHERE id = ?',
     [req.params.id],


### PR DESCRIPTION
## Summary
- expose DB globally so routers can access it
- use correct path to SQL schema and seed data without organiser table
- simplify sample data seeding
- fix organiser router paths

## Testing
- `npm run build-db`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_686a03e6d714832d86e3612a889fa34c