### PR TITLE
Fix organiser login flow and update server

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,53 +1,128 @@
 // index.js
-const express       = require('express');
-const session       = require('express-session');
-const path          = require('path');
-const portfinder    = require('portfinder');
-const cookieParser  = require('cookie-parser');
+require('dotenv').config();
+const express    = require('express');
+const session    = require('express-session');
+const flash      = require('connect-flash');
+const sqlite3    = require('sqlite3').verbose();
+const path       = require('path');
+const portfinder = require('portfinder');
 
-const db              = require('./db');
-const authRouter      = require('./routes/auth');
-const { ensureAdmin } = require('./middleware/auth');
-const organiserRouter = require('./routes/organiser');
-const attendeeRouter  = require('./routes/attendee');
-
+const DEFAULT_PORT = parseInt(process.env.PORT, 10) || 3000;
 const app = express();
-const DEFAULT_PORT = parseInt(process.env.PORT,10) || 3000;
 
-app.set('view engine','ejs');
-app.set('views', path.join(__dirname,'views'));
-app.use(express.static(path.join(__dirname,'public')));
-app.use(express.urlencoded({ extended:true }));
+/* ─── SQLite connection ────────────────────────────────────────── */
+global.db = new sqlite3.Database('database.db', err => {
+  if (err) console.error(err);
+  else console.log(`✅  Connected to SQLite: ${path.resolve('database.db')}`);
+});
+
+/* ─── View engine & static ─────────────────────────────────────── */
+app.set('view engine', 'ejs');
+app.set('views', path.join(__dirname, 'views'));
+app.use(express.static(path.join(__dirname, 'public')));
+
+/* ─── Body parsing & session ───────────────────────────────────── */
+app.use(express.urlencoded({ extended: true }));
 app.use(express.json());
-app.use(cookieParser());
-app.use(session({
-  secret: 'your-secret-here',
-  resave: false,
-  saveUninitialized: false
-}));
+app.use(
+  session({
+    secret: process.env.SESSION_SECRET || 'event-manager-secret-key',
+    resave: false,
+    saveUninitialized: false,
+    cookie: {
+      secure: process.env.NODE_ENV === 'production',
+      httpOnly: true,
+      maxAge: 24 * 60 * 60 * 1000
+    }
+  })
+);
+app.use(flash());
 
-app.use((req,res,next)=>{
-  res.locals.session = req.session;
+/* ─── Global template vars ─────────────────────────────────────── */
+app.use((req, res, next) => {
+  res.locals.success_msg = req.flash('success');
+  res.locals.error_msg   = req.flash('error');
+  res.locals.user        = req.session.user || null;
+  res.locals.theme       = req.session.theme || 'light';
   next();
 });
 
-app.use('/',          authRouter);
-app.use('/organiser', ensureAdmin, organiserRouter);
-app.use('/attendee',  attendeeRouter);
-
-app.get('/', (req,res)=> {
-  res.render('index',{ title:'Home' });
+/* ─── Theme toggle ─────────────────────────────────────────────── */
+app.use((req, res, next) => {
+  const t = req.query.theme;
+  if (t === 'light' || t === 'dark') {
+    req.session.theme = t;
+    global.db.run(
+      `INSERT OR REPLACE INTO user_preferences (session_id, theme) VALUES (?,?)`,
+      [req.sessionID, t],
+      err => {
+        if (err) console.error(err);
+      }
+    );
+  }
+  next();
 });
 
-app.use((req,res)=> {
-  res.status(404).render('404',{ title:'Not Found' });
-});
-app.use((err,req,res,next)=> {
-  console.error(err);
-  res.status(500).render('500',{ title:'Error' });
+/* ─── Auth middleware ──────────────────────────────────────────── */
+const auth = {
+  ensureOrganiser: (req, res, next) => {
+    if (req.session.user?.type === 'organiser') return next();
+    req.flash('error', 'Please log in as organiser');
+    return res.redirect('/auth/login');
+  },
+  ensureAdmin: (req, res, next) => {
+    if (req.session.user?.type === 'admin') return next();
+    req.flash('error', 'Admin access required');
+    return res.redirect('/auth/login');
+  }
+};
+
+/* ─── Routes ───────────────────────────────────────────────────── */
+app.use('/auth',    require('./routes/auth'));
+app.use('/attendee',  require('./routes/attendee'));
+app.use('/organiser', auth.ensureOrganiser, require('./routes/organiser'));
+app.use('/admin',     auth.ensureAdmin,     require('./routes/admin'));
+app.use('/users',     require('./routes/users'));
+app.use('/payment',   require('./routes/payment'));
+
+/* ─── Root route ─────────────────────────────────────────────── */
+app.get('/', (req, res) => {
+  res.render('index', { title: 'Welcome' });
 });
 
+/* ─── Theme toggle API ─────────────────────────────────────────── */
+app.post('/toggle-theme', (req, res) => {
+  const nextTheme = req.session.theme === 'dark' ? 'light' : 'dark';
+  req.session.theme = nextTheme;
+  global.db.run(
+    `INSERT OR REPLACE INTO user_preferences (session_id, theme) VALUES (?,?)`,
+    [req.sessionID, nextTheme]
+  );
+  res.json({ theme: nextTheme });
+});
+
+/* ─── Error handling ───────────────────────────────────────────── */
+app.use((req, res) => {
+  req.flash('error', 'Page not found');
+  res.redirect('/');
+});
+
+app.use((err, req, res, next) => {
+  console.error(err.stack);
+  req.flash('error', err.message || 'Something went wrong');
+  res.redirect('/');
+});
+
+/* ─── Launch server ────────────────────────────────────────────── */
 portfinder.basePort = DEFAULT_PORT;
-portfinder.getPortPromise()
-  .then(port => app.listen(port,()=>console.log(`🚀 http://localhost:${port}`)))
-  .catch(err=> { console.error('❌ No free port',err); process.exit(1);} );
+portfinder
+  .getPortPromise()
+  .then(port => {
+    app.listen(port, () => {
+      console.log(`🚀 Listening on http://localhost:${port}`);
+    });
+  })
+  .catch(err => {
+    console.error('❌ Could not start:', err);
+    process.exit(1);
+  });

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "bcrypt": "^5.1.1",
         "chart.js": "^4.4.0",
         "concurrently": "^9.2.0",
+        "connect-flash": "^0.1.1",
         "cookie-parser": "^1.4.7",
         "dotenv": "^17.0.1",
         "ejs": "^3.1.10",
@@ -1067,6 +1068,14 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/connect-flash": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/connect-flash/-/connect-flash-0.1.1.tgz",
+      "integrity": "sha512-2rcfELQt/ZMP+SM/pG8PyhJRaLKp+6Hk2IUBNkEit09X+vwn3QsAL3ZbYtxUn7NVPzbMTSLRDhqe0B/eh30RYA==",
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/console-control-strings": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "axios": "^1.5.0",
     "bcrypt": "^5.1.1",
     "chart.js": "^4.4.0",
+    "connect-flash": "^0.1.1",
     "concurrently": "^9.2.0",
     "cookie-parser": "^1.4.7",
     "dotenv": "^17.0.1",

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -32,9 +32,11 @@ router.post('/login', (req, res, next) => {
         if (!ok) {
           return res.render('login', { title: 'Login', errors: ['Invalid credentials'] });
         }
-        req.session.organiserId = user.id;
-        req.session.username    = user.username;
-        req.session.isAdmin     = true;
+        req.session.user = {
+          id: user.id,
+          type: 'organiser',
+          username: user.username
+        };
         res.redirect('/organiser');
       });
     }

--- a/routes/organiser.js
+++ b/routes/organiser.js
@@ -259,7 +259,7 @@ router.post('/events/:id/edit', [
  * POST /organiser/events/:id/publish - Publish event
  * Changes event state from draft to published and sets publication timestamp
  */
-router.post('/organiser/events/:id/publish', (req, res, next) => {
+router.post('/events/:id/publish', (req, res, next) => {
   db.run(
     `UPDATE events 
      SET state = 'published', published_at = datetime('now')
@@ -276,7 +276,7 @@ router.post('/organiser/events/:id/publish', (req, res, next) => {
  * DELETE /organiser/events/:id - Delete event
  * Removes event and all associated tickets and bookings
  */
-router.delete('/organiser/events/:id', (req, res, next) => {
+router.delete('/events/:id', (req, res, next) => {
   db.run(
     'DELETE FROM events WHERE id = ?',
     [req.params.id],

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -9,7 +9,7 @@
       <% }) %>
     </ul>
   <% } %>
-  <form action="/login" method="POST" class="space-y-4">
+  <form action="/auth/login" method="POST" class="space-y-4">
     <div>
       <label class="block">Username</label>
       <input name="username" class="w-full border px-2 py-1" required>

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -91,3 +91,16 @@
                 <i class="fas fa-user-circle mr-1"></i>Attendee Login
               </a>
             </div>
+          <% } %>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+  <!-- Open Barba wrapper -->
+  <div id="barba-wrapper">
+    <div
+      class="barba-container"
+      data-barba="container"
+      data-barba-namespace="<%= title.toLowerCase().replace(/\s+/g, '-') %>"
+    >


### PR DESCRIPTION
## Summary
- modernize root server with theme and flash middleware
- use unified session object for organiser auth
- update login form action to match new auth routes
- add `connect-flash` dependency

## Testing
- `npm run build-db`
- `npm start` (server launched)

------
https://chatgpt.com/codex/tasks/task_e_686a03e6d714832d86e3612a889fa34c